### PR TITLE
chore: remove dead code, consolidate imports, fix event serialization

### DIFF
--- a/src/spec_kitty_runtime/engine.py
+++ b/src/spec_kitty_runtime/engine.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
@@ -12,6 +13,7 @@ from uuid import uuid4
 import yaml
 from pydantic import BaseModel, ConfigDict
 
+from spec_kitty_runtime.contracts import RemediationPayload
 from spec_kitty_runtime.discovery import DiscoveryContext, discover_missions, load_mission_template
 from spec_kitty_events.mission_next import (
     DecisionInputAnsweredPayload,
@@ -33,10 +35,12 @@ from spec_kitty_runtime.events import (
     RuntimeEventEmitter,
 )
 from spec_kitty_runtime.planner import plan_next
-from spec_kitty_runtime.raci import resolve_raci
+from spec_kitty_runtime.raci import infer_raci, resolve_raci
 from spec_kitty_runtime.schema import (
     ActorIdentity,
     AuditStep,
+    ContextType,
+    ContextTypeRegistry,
     DecisionAnswer,
     DecisionRequest,
     MissionPolicySnapshot,
@@ -45,7 +49,21 @@ from spec_kitty_runtime.schema import (
     MissionTemplate,
     NextDecision,
     PromptStep,
+    RACIRoleBinding,
+    ResolvedRACIBinding,
+    StepContextContract,
     load_mission_template_file,
+)
+from spec_kitty_runtime.significance import (
+    SignificanceEvaluatedPayload,
+    SignificanceScore,
+    SoftGateDecision,
+    TimeoutExpiredPayload,
+    TimeoutEscalationResult,
+    compute_escalation_targets,
+    evaluate_significance,
+    parse_band_cutoffs_from_policy,
+    parse_timeout_from_policy,
 )
 
 
@@ -87,7 +105,7 @@ def _append_event(run_dir: Path, event_type: str, payload: dict[str, Any]) -> No
         "payload": payload,
     }
     with open(event_file, "a", encoding="utf-8") as handle:
-        handle.write(json.dumps(event, sort_keys=True) + "\n")
+        handle.write(json.dumps(event, sort_keys=True, default=str) + "\n")
 
 
 def _read_snapshot(run_dir: Path) -> MissionRunSnapshot:
@@ -302,13 +320,12 @@ def next_step(
             decisions[f"significance:{decision.decision_id}"] = _sig_score.model_dump(mode="json")
 
             # Resolve RACI for the audit step (needed for timeout escalation)
-            from spec_kitty_runtime.raci import infer_raci as _infer_raci
             _raci_inputs = {**inputs, "agent_id": agent_id}
             try:
                 _resolved_raci = resolve_raci(_sig_step, _raci_inputs, effective_policy)
                 decisions[f"raci:{_sig_step_id}"] = _resolved_raci.model_dump(mode="json")
             except MissionRuntimeError:
-                _inferred = _infer_raci(_sig_step, effective_policy)
+                _inferred = infer_raci(_sig_step, effective_policy)
                 decisions[f"raci:{_sig_step_id}"] = _inferred.model_dump(mode="json")
 
             # Emit significance evaluated event
@@ -386,7 +403,6 @@ def next_step(
         # actor IDs. Fail-closed enforcement happens in provide_decision_answer().
         step_obj = _find_step_by_id(template, decision.step_id)
         if step_obj is not None:
-            from spec_kitty_runtime.raci import infer_raci
             raci_inputs = {**inputs, "agent_id": agent_id}
             try:
                 resolved_raci = resolve_raci(step_obj, raci_inputs, effective_policy)
@@ -701,20 +717,6 @@ def _authority_metadata(
 # ============================================================================
 
 
-from spec_kitty_runtime.significance import (
-    SignificanceEvaluatedPayload,
-    SignificanceScore,
-    SoftGateDecision,
-    TimeoutExpiredPayload,
-    TimeoutEscalationResult,
-    compute_escalation_targets,
-    evaluate_significance,
-    parse_band_cutoffs_from_policy,
-    parse_timeout_from_policy,
-)
-from spec_kitty_runtime.schema import RACIRoleBinding, ResolvedRACIBinding
-
-
 def notify_decision_timeout(
     run_ref: MissionRunRef,
     decision_id: str,
@@ -831,11 +833,6 @@ def notify_decision_timeout(
 # ============================================================================
 # WP02: Transition-Gate Engine - Deterministic Context Resolution
 # ============================================================================
-
-
-import re
-from spec_kitty_runtime.contracts import RemediationPayload
-from spec_kitty_runtime.schema import ContextType, ContextTypeRegistry, StepContextContract
 
 
 class TransitionGate:

--- a/src/spec_kitty_runtime/planner.py
+++ b/src/spec_kitty_runtime/planner.py
@@ -59,21 +59,6 @@ def _resolve_next_unified_step(
     return None
 
 
-# Keep the old name as an alias so existing tests/code that call _resolve_next_step still work.
-def _resolve_next_step(
-    template: MissionTemplate,
-    snapshot: MissionRunSnapshot,
-) -> PromptStep | None:
-    """Legacy wrapper — returns only PromptStep or None.
-
-    New callers should use _resolve_next_unified_step.
-    """
-    result = _resolve_next_unified_step(template, snapshot)
-    if isinstance(result, PromptStep):
-        return result
-    return None
-
-
 def _has_remaining_steps(
     template: MissionTemplate,
     snapshot: MissionRunSnapshot,

--- a/src/spec_kitty_runtime/schema.py
+++ b/src/spec_kitty_runtime/schema.py
@@ -56,9 +56,6 @@ class DecisionAnswer(BaseModel):
 # RACI role model types (WP06)
 # ---------------------------------------------------------------------------
 
-_VALID_ACTOR_TYPES = frozenset({"human", "llm", "service"})
-
-
 class RACIRoleBinding(BaseModel):
     """Single actor-role binding in a RACI assignment."""
     model_config = ConfigDict(frozen=True, extra="forbid")


### PR DESCRIPTION
## Summary

Low-risk, high-impact cleanup identified by systematic code review across reuse, quality, and efficiency dimensions. All 730 tests pass before and after these changes.

### Changes

- **Remove unused `_VALID_ACTOR_TYPES` in `schema.py`** (dead code)
  - *Why low-risk:* The constant was defined at line 59 but never referenced anywhere in `schema.py` or imported from it. The identical constant in `diagnostics.py` (which *is* used) is untouched.
  - *Why high-impact:* Eliminates confusion about the canonical location of this constant.

- **Remove dead `_resolve_next_step` legacy wrapper in `planner.py`** (dead code)
  - *Why low-risk:* Grep confirms zero callers across all source and test files. The function was a compatibility shim for code that has already migrated to `_resolve_next_unified_step`.
  - *Why high-impact:* Removes 13 lines of dead code that could mislead contributors into using a deprecated code path.

- **Consolidate three mid-file import blocks in `engine.py` to the top** (PEP 8)
  - *Why low-risk:* Pure import reorganization -- `significance`, `schema` extras (`RACIRoleBinding`, `ResolvedRACIBinding`, `ContextType`, `ContextTypeRegistry`, `StepContextContract`), `contracts.RemediationPayload`, and `import re` are moved from lines 704+, 715, 836-838 to the standard top-level import section. No behavioral change.
  - *Why high-impact:* Makes dependencies immediately visible; eliminates the anti-pattern of scattering imports throughout a 1400+ line file.

- **Remove two redundant inline `from raci import infer_raci` in `engine.py`** (code reuse)
  - *Why low-risk:* `infer_raci` is now imported once at the top alongside the already-imported `resolve_raci`. The inline imports at lines 305 and 389 were performing the same import redundantly on every call.
  - *Why high-impact:* Removes unnecessary repeated imports and inconsistent aliasing (`infer_raci as _infer_raci` vs `infer_raci`).

- **Add `default=str` to `_append_event` JSON serialization** (bug prevention)
  - *Why low-risk:* `default=str` is strictly additive -- all currently-serializable values serialize identically. Only previously-crashing values (datetime, Path, etc.) gain a fallback.
  - *Why high-impact:* Fixes inconsistency with `JsonlEventLog.append` (which already uses `default=str`) and prevents potential runtime `TypeError` crashes if any event payload contains non-JSON-native types that weren't pre-serialized via `model_dump(mode="json")`.

## Test plan

- [x] All 730 existing tests pass (verified locally before and after changes)
- [x] `import spec_kitty_runtime` succeeds without errors
- [x] No public API changes -- only internal reorganization and dead code removal

Generated with [Claude Code](https://claude.com/claude-code)