### PR TITLE
Add canonical acceptance workflow

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,0 +1,122 @@
+name: Acceptance
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+  workflow_dispatch:
+    inputs:
+      candidate_package:
+        description: Optional candidate package under verification
+        required: false
+        default: ""
+        type: string
+      candidate_version:
+        description: Optional candidate version under verification
+        required: false
+        default: ""
+        type: string
+      candidate_source:
+        description: Optional candidate source descriptor
+        required: false
+        default: ""
+        type: string
+      candidate_ref:
+        description: Optional candidate git ref or artifact identifier
+        required: false
+        default: ""
+        type: string
+      verification_profile:
+        description: Verification profile name
+        required: false
+        default: default
+        type: string
+  workflow_call:
+    inputs:
+      candidate_package:
+        required: false
+        type: string
+        default: ""
+      candidate_version:
+        required: false
+        type: string
+        default: ""
+      candidate_source:
+        required: false
+        type: string
+        default: ""
+      candidate_ref:
+        required: false
+        type: string
+        default: ""
+      verification_profile:
+        required: false
+        type: string
+        default: default
+
+concurrency:
+  group: acceptance-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  acceptance:
+    runs-on: ubuntu-latest
+    env:
+      CANDIDATE_PACKAGE: ${{ inputs.candidate_package || '' }}
+      CANDIDATE_VERSION: ${{ inputs.candidate_version || '' }}
+      CANDIDATE_SOURCE: ${{ inputs.candidate_source || '' }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test and build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[test]" build twine
+
+      - name: Apply candidate dependency override
+        if: ${{ env.CANDIDATE_PACKAGE != '' }}
+        run: |
+          set -euo pipefail
+
+          case "${CANDIDATE_SOURCE:-pypi}" in
+            ""|pypi)
+              python -m pip install --upgrade "${CANDIDATE_PACKAGE}==${CANDIDATE_VERSION}"
+              ;;
+            testpypi)
+              python -m pip install --upgrade \
+                --index-url https://test.pypi.org/simple/ \
+                --extra-index-url https://pypi.org/simple \
+                "${CANDIDATE_PACKAGE}==${CANDIDATE_VERSION}"
+              ;;
+            http*|*.whl|git+*)
+              python -m pip install --upgrade "${CANDIDATE_SOURCE}"
+              ;;
+            *)
+              echo "Unsupported candidate_source '${CANDIDATE_SOURCE}'"
+              exit 1
+              ;;
+          esac
+
+      - name: Run tests
+        run: pytest -q
+
+      - name: Validate dependency compatibility matrix
+        run: python scripts/release/validate_dependency_matrix.py
+
+      - name: Validate dependency policy
+        run: python scripts/release/validate_dependency_policy.py
+
+      - name: Build package artifacts
+        run: |
+          python -m build
+          twine check dist/*

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -18,7 +18,13 @@ on:
         type: boolean
 
 jobs:
+  acceptance:
+    uses: ./.github/workflows/acceptance.yml
+    with:
+      verification_profile: release
+
   build:
+    needs: acceptance
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -15,7 +15,13 @@ on:
         type: boolean
 
 jobs:
+  acceptance:
+    uses: ./.github/workflows/acceptance.yml
+    with:
+      verification_profile: release
+
   build:
+    needs: acceptance
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Summary

Adds a canonical `.github/workflows/acceptance.yml` to `spec-kitty-runtime` and makes the publish workflows depend on that canonical acceptance gate.

## What changed

- add `.github/workflows/acceptance.yml`
- move the existing release-time checks into a normal reusable acceptance surface
- make `publish-testpypi.yml` depend on acceptance
- make `publish-pypi.yml` depend on acceptance

## Why

This is the phase-1 implementation for #8 and the planning work in local commit `b5379d3`.

The repo already had useful dependency-matrix and policy checks, but only at publish time. This makes them visible in a normal PR/push workflow and reusable for downstream consumer verification later.

## Validation

- parsed touched workflow YAML successfully with Ruby's YAML loader
