### PR TITLE
fix: emit canonical mission_type in runtime events

### DIFF
--- a/src/spec_kitty_runtime/engine.py
+++ b/src/spec_kitty_runtime/engine.py
@@ -209,7 +209,7 @@ def start_mission_run(
     )
     _write_snapshot(run_dir, snapshot)
     actor = RuntimeActorIdentity(actor_id="system", actor_type="service")
-    payload = MissionRunStartedPayload(run_id=run_id, mission_key=template.mission.key, actor=actor)
+    payload = MissionRunStartedPayload(run_id=run_id, mission_type=template.mission.key, actor=actor)
     _append_event(run_dir, MISSION_RUN_STARTED, payload.model_dump(mode="json"))
     emitter.emit_mission_run_started(payload)
 
@@ -443,7 +443,7 @@ def next_step(
         # not on re-polls of an already-terminal run.
         mc_actor = RuntimeActorIdentity(actor_id=agent_id, actor_type="llm")
         mc_payload = MissionRunCompletedPayload(
-            run_id=snapshot.run_id, mission_key=snapshot.mission_key, actor=mc_actor,
+            run_id=snapshot.run_id, mission_type=snapshot.mission_key, actor=mc_actor,
         )
         _append_event(run_dir, MISSION_RUN_COMPLETED, mc_payload.model_dump(mode="json"))
         emitter.emit_mission_run_completed(mc_payload)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -21,7 +21,7 @@ def test_null_emitter_is_noop() -> None:
 
     actor = RuntimeActorIdentity(actor_id="a1", actor_type="llm")
     emitter.emit_mission_run_started(
-        MissionRunStartedPayload(run_id="r1", mission_key="key", actor=actor)
+        MissionRunStartedPayload(run_id="r1", mission_type="key", actor=actor)
     )
     emitter.emit_next_step_issued(
         NextStepIssuedPayload(run_id="r1", step_id="S1", agent_id="agent-1", actor=actor)
@@ -36,7 +36,7 @@ def test_null_emitter_is_noop() -> None:
         DecisionInputAnsweredPayload(run_id="r1", decision_id="d1", answer="A", actor=actor)
     )
     emitter.emit_mission_run_completed(
-        MissionRunCompletedPayload(run_id="r1", mission_key="key", actor=actor)
+        MissionRunCompletedPayload(run_id="r1", mission_type="key", actor=actor)
     )
 
 


### PR DESCRIPTION
This unblocks the spec-kitty 3.0 contract chain.

- emit `mission_type` instead of `mission_key` in runtime lifecycle payloads
- align null-emitter tests to the canonical event models

Local verification:
- `uv run python -m pytest -q` (730 passed)