### PR TITLE
fix: update spec-kitty-events dependency pin from 3.0.0 to 3.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.egg-info/
 .pytest_cache/
 .venv/
+.idea
 
 # Added by Spec Kitty CLI (auto-managed)
 .claude/

--- a/docs/releases/dependency-compatibility-matrix.toml
+++ b/docs/releases/dependency-compatibility-matrix.toml
@@ -29,3 +29,9 @@ notes = "Approved-lane alignment release pinned to the canonical spec-kitty-even
 
 [runtime."0.4.3"]
 notes = "Bugfix: update dependency pin to spec-kitty-events 3.0.0 to match mission_next imports."
+
+[runtime."0.4.4".dependencies]
+"spec-kitty-events" = "3.2.0"
+
+[runtime."0.4.4"]
+notes = "Bugfix: update dependency pin to spec-kitty-events 3.2.0 to align with spec-kitty-cli 3.2.0a2."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-runtime"
-version = "0.4.3"
+version = "0.4.4"
 description = "Canonical mission runtime for deterministic next-step planning"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -16,7 +16,7 @@ dependencies = [
   "pydantic>=2.0,<3.0",
   "pyyaml>=6.0",
   "jsonschema>=4.0",
-  "spec-kitty-events==3.0.0"
+  "spec-kitty-events==3.2.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Bumps runtime version to 0.4.4 to resolve conflict with spec-kitty-cli 3.2.0a1 which requires spec-kitty-events==3.2.0.

See issue in downstream builds:

```bash
[5](https://github.com/Priivacy-ai/spec-kitty/actions/runs/24705188394/job/72256803923#step:4:96)
The conflict is caused by:
    spec-kitty-cli 3.2.0a1 depends on spec-kitty-events==3.2.0
    spec-kitty-cli[test] 3.2.0a1 depends on spec-kitty-events==3.2.0
    spec-kitty-runtime 0.4.3 depends on spec-kitty-events==3.0.0

Additionally, some packages in these conflicts have no matching distributions available for your environment:
    spec-kitty-events
```

e.g. https://github.com/Priivacy-ai/spec-kitty/actions/runs/24705188394/job/72256803923#logs