### PR TITLE
chore: align runtime with analytics event contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.4.5 - 2026-04-22
+
+**Release-train alignment** — repins the runtime to the analytics-enabled events
+contract required by Mission Scorecard telemetry.
+
+### Fixed
+
+- Updated dependency from `spec-kitty-events==3.2.0` to
+  `spec-kitty-events==3.3.0`.
+- Added the corresponding dependency-compatibility matrix entry so the release
+  gates validate the current train.
+
 ## 0.4.3 - 2026-04-06
 
 **Bugfix** — corrects the dependency pin that caused `ModuleNotFoundError` at import time.

--- a/docs/releases/dependency-compatibility-matrix.toml
+++ b/docs/releases/dependency-compatibility-matrix.toml
@@ -35,3 +35,9 @@ notes = "Bugfix: update dependency pin to spec-kitty-events 3.0.0 to match missi
 
 [runtime."0.4.4"]
 notes = "Bugfix: update dependency pin to spec-kitty-events 3.2.0 to align with spec-kitty-cli 3.2.0a2."
+
+[runtime."0.4.5".dependencies]
+"spec-kitty-events" = "3.3.0"
+
+[runtime."0.4.5"]
+notes = "Release-train alignment release pinned to spec-kitty-events 3.3.0 for mission analytics telemetry."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-runtime"
-version = "0.4.4"
+version = "0.4.5"
 description = "Canonical mission runtime for deterministic next-step planning"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -16,7 +16,7 @@ dependencies = [
   "pydantic>=2.0,<3.0",
   "pyyaml>=6.0",
   "jsonschema>=4.0",
-  "spec-kitty-events==3.2.0"
+  "spec-kitty-events==3.3.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- repin spec-kitty-runtime to spec-kitty-events 3.3.0
- bump the runtime release metadata to 0.4.5
- update the dependency compatibility matrix for the analytics release train

## Verification
- .venv/bin/python -m pytest -q
- .venv/bin/python scripts/release/validate_dependency_matrix.py
- PIP_FIND_LINKS="../spec-kitty-events/dist ../spec-kitty-runtime/dist" .venv/bin/python scripts/release/check_exact_install.py --package spec-kitty-runtime