### PR TITLE
Classify runtime logs for TeamSpace migration

### DIFF
--- a/docs/teamspace-migration-runtime-logs.md
+++ b/docs/teamspace-migration-runtime-logs.md
@@ -1,0 +1,20 @@
+# TeamSpace Migration Runtime Log Boundary
+
+For the public TeamSpace launch migration, `spec-kitty-runtime` logs are **local-only side logs**.
+
+`run.events.jsonl` rows are useful audit evidence for mission-next execution, but they are not WP lane authority and they are not full TeamSpace event envelopes. Launch migration tooling should report them with disposition `local_only_side_log` / `deferred_not_launch_import`.
+
+In scope for classification:
+
+- `MissionNextInvoked`
+- `MissionRunStarted`
+- `NextStepIssued`
+- `MissionRunCompleted`
+
+Out of scope for launch import:
+
+- adapting runtime rows into TeamSpace events
+- reducing runtime rows into `status.json`
+- treating runtime event types as `WPStatusChanged`
+
+The CLI migration doctor owns repository-wide discovery of `.kittify/runtime/**/run.events.jsonl`; this package owns the event-type boundary and fixture coverage.

--- a/src/spec_kitty_runtime/teamspace_migration.py
+++ b/src/spec_kitty_runtime/teamspace_migration.py
@@ -1,0 +1,108 @@
+"""TeamSpace launch-migration classification for runtime side logs.
+
+Runtime ``run.events.jsonl`` files are local mission-next audit logs. They
+carry canonical mission-next payloads, but they are not WP status authority and
+are not full TeamSpace event envelopes for the launch migration.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+RUNTIME_SIDE_LOG_DISPOSITION = "local_only_side_log"
+RUNTIME_SIDE_LOG_REASON = "deferred_not_launch_import"
+
+RUNTIME_SIDE_LOG_EVENT_TYPES = frozenset(
+    {
+        "MissionNextInvoked",
+        "MissionRunStarted",
+        "NextStepIssued",
+        "NextStepAutoCompleted",
+        "DecisionInputRequested",
+        "DecisionInputAnswered",
+        "MissionRunCompleted",
+        "SignificanceEvaluated",
+        "DecisionTimeoutExpired",
+    }
+)
+
+TEAMSPACE_STATUS_EVENT_TYPES = frozenset({"WPStatusChanged"})
+
+
+@dataclass(frozen=True)
+class RuntimeLogClassification:
+    """Classification summary for one runtime JSONL log."""
+
+    artifact_path: str
+    row_count: int
+    event_type_counts: dict[str, int]
+    unknown_event_types: tuple[str, ...]
+    disposition: str = RUNTIME_SIDE_LOG_DISPOSITION
+    reason: str = RUNTIME_SIDE_LOG_REASON
+    status_authority: bool = False
+    direct_teamspace_import: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "artifact_path": self.artifact_path,
+            "row_count": self.row_count,
+            "event_type_counts": dict(self.event_type_counts),
+            "unknown_event_types": list(self.unknown_event_types),
+            "disposition": self.disposition,
+            "reason": self.reason,
+            "status_authority": self.status_authority,
+            "direct_teamspace_import": self.direct_teamspace_import,
+        }
+
+
+def classify_runtime_log(path: Path, *, display_path: str | None = None) -> RuntimeLogClassification:
+    """Classify a runtime ``run.events.jsonl`` file for TeamSpace migration.
+
+    The classifier is deterministic and read-only. It never attempts to adapt
+    runtime rows into TeamSpace envelopes; launch migration should report them
+    as explicit side logs.
+    """
+    event_type_counts: Counter[str] = Counter()
+    row_count = 0
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            row_count += 1
+            row = json.loads(stripped)
+            event_type = row.get("event_type") if isinstance(row, dict) else None
+            event_type_counts[str(event_type or "<missing>")] += 1
+
+    unknown = tuple(sorted(key for key in event_type_counts if key not in RUNTIME_SIDE_LOG_EVENT_TYPES))
+    return RuntimeLogClassification(
+        artifact_path=display_path or str(path),
+        row_count=row_count,
+        event_type_counts=dict(sorted(event_type_counts.items())),
+        unknown_event_types=unknown,
+    )
+
+
+def is_runtime_side_log_event_type(event_type: str) -> bool:
+    """Return True for event types treated as runtime side logs at launch."""
+    return event_type in RUNTIME_SIDE_LOG_EVENT_TYPES
+
+
+def is_teamspace_status_authority_event_type(event_type: str) -> bool:
+    """Return True only for TeamSpace status-authority event types."""
+    return event_type in TEAMSPACE_STATUS_EVENT_TYPES
+
+
+__all__ = [
+    "RUNTIME_SIDE_LOG_DISPOSITION",
+    "RUNTIME_SIDE_LOG_EVENT_TYPES",
+    "RUNTIME_SIDE_LOG_REASON",
+    "RuntimeLogClassification",
+    "classify_runtime_log",
+    "is_runtime_side_log_event_type",
+    "is_teamspace_status_authority_event_type",
+]

--- a/tests/fixtures/teamspace_migration/runtime_side_log.jsonl
+++ b/tests/fixtures/teamspace_migration/runtime_side_log.jsonl
@@ -1,0 +1,4 @@
+{"event_type":"MissionNextInvoked","payload":{"mission_key":"runtime-demo","run_id":"run-001"},"timestamp":"2026-01-01T00:00:00+00:00"}
+{"event_type":"MissionRunStarted","payload":{"actor":{"actor_id":"agent-1","actor_type":"llm"},"mission_type":"software-dev","run_id":"run-001"},"timestamp":"2026-01-01T00:00:01+00:00"}
+{"event_type":"NextStepIssued","payload":{"actor":{"actor_id":"agent-1","actor_type":"llm"},"agent_id":"agent-1","run_id":"run-001","step_id":"S1"},"timestamp":"2026-01-01T00:00:02+00:00"}
+{"event_type":"MissionRunCompleted","payload":{"actor":{"actor_id":"agent-1","actor_type":"llm"},"mission_type":"software-dev","run_id":"run-001"},"timestamp":"2026-01-01T00:00:03+00:00"}

--- a/tests/test_teamspace_migration.py
+++ b/tests/test_teamspace_migration.py
@@ -1,0 +1,41 @@
+"""Runtime log classification for TeamSpace launch migration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from spec_kitty_runtime.teamspace_migration import (
+    RUNTIME_SIDE_LOG_DISPOSITION,
+    RUNTIME_SIDE_LOG_REASON,
+    classify_runtime_log,
+    is_runtime_side_log_event_type,
+    is_teamspace_status_authority_event_type,
+)
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "teamspace_migration" / "runtime_side_log.jsonl"
+
+
+def test_runtime_side_log_fixture_is_reported_as_deferred_local_side_log() -> None:
+    classification = classify_runtime_log(FIXTURE, display_path=".kittify/runtime/runs/run-001/run.events.jsonl")
+
+    assert classification.row_count == 4
+    assert classification.disposition == RUNTIME_SIDE_LOG_DISPOSITION
+    assert classification.reason == RUNTIME_SIDE_LOG_REASON
+    assert not classification.status_authority
+    assert not classification.direct_teamspace_import
+    assert classification.unknown_event_types == ()
+    assert classification.event_type_counts == {
+        "MissionNextInvoked": 1,
+        "MissionRunCompleted": 1,
+        "MissionRunStarted": 1,
+        "NextStepIssued": 1,
+    }
+
+
+def test_runtime_event_types_are_not_wp_status_authority() -> None:
+    for event_type in ("MissionNextInvoked", "NextStepIssued", "MissionRunStarted", "MissionRunCompleted"):
+        assert is_runtime_side_log_event_type(event_type)
+        assert not is_teamspace_status_authority_event_type(event_type)
+
+    assert is_teamspace_status_authority_event_type("WPStatusChanged")

--- a/uv.lock
+++ b/uv.lock
@@ -407,20 +407,20 @@ wheels = [
 
 [[package]]
 name = "spec-kitty-events"
-version = "3.0.0"
+version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-ulid" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/ff/fe70d757505e2b786decf4708d20b9844d860f563c3decaf9fdefa92ab19/spec_kitty_events-3.0.0.tar.gz", hash = "sha256:97383f3f8cf7e0c4722a318749414dc560e3e38aef943c02dbfb4be16c451c7d", size = 152627 }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/20/5fbbaaa943672199b3aceced851392048ffea6017121cc884afb0c444453/spec_kitty_events-3.3.0.tar.gz", hash = "sha256:8ba7d1fb1c79e1be2b35d6cc11f529723984099b86f8572a5b77de22b88f964a", size = 162421 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/f0/0b7320de5dd8434359733930e5ec99a966f7bc807d69f2e88a191481ae66/spec_kitty_events-3.0.0-py3-none-any.whl", hash = "sha256:eb468256303947c000b43cac2b077220b7d47dc5f98b282b89f4ac5779ceee51", size = 227397 },
+    { url = "https://files.pythonhosted.org/packages/05/df/513f986d0f9c18b7bbfcced6d117e25577bfda10a44178aeac828e91c3a7/spec_kitty_events-3.3.0-py3-none-any.whl", hash = "sha256:9b271e96dc222e3321c175c039e34113eb6b623306f0467c5fa1847bbda97841", size = 246431 },
 ]
 
 [[package]]
 name = "spec-kitty-runtime"
-version = "0.4.3"
+version = "0.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },
@@ -440,7 +440,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0,<3.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "spec-kitty-events", specifier = "==3.0.0" },
+    { name = "spec-kitty-events", specifier = "==3.3.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add a deterministic runtime `run.events.jsonl` classifier for TeamSpace launch migration planning.
- Document that runtime logs are local side logs at launch, not TeamSpace status authority and not direct import payloads.
- Add fixtures/tests covering runtime side-log classification and status-authority boundaries.

## Testing

- `uv run pytest tests/test_teamspace_migration.py tests/test_events.py tests/test_contract_parity.py -q`  
  Result: 11 passed.
- `uv run ruff check src/spec_kitty_runtime/teamspace_migration.py tests/test_teamspace_migration.py`
- `uv run mypy --strict --follow-imports=skip src/spec_kitty_runtime/teamspace_migration.py`
- `git diff --check`

## Follow-ups

- Full strict mypy still exposes existing unrelated runtime package baseline errors. Tracked in #18.

Refs Priivacy-ai/spec-kitty#920.
